### PR TITLE
Handle program_info in PMT

### DIFF
--- a/src/ts/mod.rs
+++ b/src/ts/mod.rs
@@ -96,7 +96,6 @@ mod test {
 
     #[test]
     fn pmt() {
-        dbg!(pmt_packet_bytes().len());
         let mut bytes = Vec::new();
         bytes.extend(pat_packet_bytes());
         bytes.extend(pmt_packet_bytes());
@@ -107,7 +106,8 @@ mod test {
         track_try_unwrap!(writer.write_ts_packet(&packet));
 
         let packet = track_try_unwrap!(reader.read_ts_packet()).unwrap();
-        assert_eq!(packet, pmt_packet());
+        assert_eq!(packet.header, pmt_packet().header);
+        assert_eq!(packet.payload, pmt_packet().payload);
         track_try_unwrap!(writer.write_ts_packet(&packet));
 
         let mut reader = TsPacketReader::new(&writer.stream()[..]);

--- a/src/ts/mod.rs
+++ b/src/ts/mod.rs
@@ -38,6 +38,7 @@ mod writer;
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::es::StreamType;
 
     #[test]
     fn pat() {
@@ -89,6 +90,85 @@ mod test {
                     program_num: 1,
                     program_map_pid: Pid::new(480).unwrap(),
                 }],
+            })),
+        }
+    }
+
+    #[test]
+    fn pmt() {
+        dbg!(pmt_packet_bytes().len());
+        let mut bytes = Vec::new();
+        bytes.extend(pat_packet_bytes());
+        bytes.extend(pmt_packet_bytes());
+        let mut reader = TsPacketReader::new(&bytes[..]);
+        let mut writer = TsPacketWriter::new(Vec::new());
+
+        let packet = track_try_unwrap!(reader.read_ts_packet()).unwrap();
+        track_try_unwrap!(writer.write_ts_packet(&packet));
+
+        let packet = track_try_unwrap!(reader.read_ts_packet()).unwrap();
+        assert_eq!(packet, pmt_packet());
+        track_try_unwrap!(writer.write_ts_packet(&packet));
+
+        let mut reader = TsPacketReader::new(&writer.stream()[..]);
+        track_try_unwrap!(reader.read_ts_packet()).unwrap();
+        let packet = track_try_unwrap!(reader.read_ts_packet()).unwrap();
+        assert_eq!(packet.header, pmt_packet().header);
+        assert_eq!(packet.payload, pmt_packet().payload);
+        assert_eq!(track_try_unwrap!(reader.read_ts_packet()), None);
+    }
+
+    fn pmt_packet_bytes() -> &'static [u8] {
+        &[
+            71, 65, 224, 48, 0, 0, 2, 176, 34, 0, 1, 193, 0, 0, 225, 2, 240, 6, 5, 4, 67, 85, 69,
+            73, 134, 225, 3, 240, 0, 15, 225, 1, 240, 0, 27, 225, 2, 240, 0, 225, 243, 90, 60, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255,
+        ][..]
+    }
+
+    fn pmt_packet() -> TsPacket {
+        TsPacket {
+            header: TsHeader {
+                transport_error_indicator: false,
+                transport_priority: false,
+                pid: Pid::new(480).unwrap(),
+                transport_scrambling_control: TransportScramblingControl::NotScrambled,
+                continuity_counter: ContinuityCounter::from_u8(0).unwrap(),
+            },
+            adaptation_field: None,
+            payload: Some(TsPayload::Pmt(payload::Pmt {
+                program_num: 1,
+                pcr_pid: Some(Pid::new(258).unwrap()),
+                version_number: VersionNumber::new(),
+                program_info: vec![Descriptor {
+                    tag: 5,
+                    data: b"CUEI".to_vec(),
+                }],
+                es_info: vec![
+                    EsInfo {
+                        stream_type: StreamType::Dts8ChannelLosslessAudio,
+                        elementary_pid: Pid::new(259).unwrap(),
+                        descriptors: vec![],
+                    },
+                    EsInfo {
+                        stream_type: StreamType::AdtsAac,
+                        elementary_pid: Pid::new(257).unwrap(),
+                        descriptors: vec![],
+                    },
+                    EsInfo {
+                        stream_type: StreamType::H264,
+                        elementary_pid: Pid::new(258).unwrap(),
+                        descriptors: vec![],
+                    },
+                ],
             })),
         }
     }

--- a/src/ts/reader.rs
+++ b/src/ts/reader.rs
@@ -83,7 +83,7 @@ impl<R: Read> ReadTsPacket for TsPacketReader<R> {
                     match kind {
                         PidKind::Pmt => {
                             let pmt = track!(Pmt::read_from(&mut reader))?;
-                            for es in &pmt.table {
+                            for es in &pmt.es_info {
                                 self.pids.insert(es.elementary_pid, PidKind::Pes);
                             }
                             TsPayload::Pmt(pmt)


### PR DESCRIPTION
This adds read and write handling of program_info in the program map table. This also renames pmt.table to pmt.es_info to give it a more descriptive name.