### PR TITLE
Add support for writing to a generic section stream

### DIFF
--- a/src/ts/mod.rs
+++ b/src/ts/mod.rs
@@ -21,6 +21,7 @@ pub mod payload {
     pub use super::pat::Pat;
     pub use super::pes::Pes;
     pub use super::pmt::Pmt;
+    pub use super::section::Section;
     pub use super::types::Bytes;
 }
 
@@ -32,6 +33,7 @@ mod pes;
 mod pmt;
 mod psi;
 mod reader;
+mod section;
 mod types;
 mod writer;
 

--- a/src/ts/packet.rs
+++ b/src/ts/packet.rs
@@ -1,5 +1,5 @@
 use super::adaptation_field::AdaptationFieldControl;
-use crate::ts::payload::{Bytes, Null, Pat, Pes, Pmt};
+use crate::ts::payload::{Bytes, Null, Pat, Pes, Pmt, Section};
 use crate::ts::{AdaptationField, ContinuityCounter, Pid, TransportScramblingControl};
 use crate::{ErrorKind, Result};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -151,6 +151,7 @@ pub enum TsPayload {
     Pat(Pat),
     Pmt(Pmt),
     Pes(Pes),
+    Section(Section),
     Null(Null),
     Raw(Bytes),
 }
@@ -160,6 +161,7 @@ impl TsPayload {
             TsPayload::Pat(ref x) => track!(x.write_to(writer)),
             TsPayload::Pmt(ref x) => track!(x.write_to(writer)),
             TsPayload::Pes(ref x) => track!(x.write_to(writer)),
+            TsPayload::Section(ref x) => track!(x.write_to(writer)),
             TsPayload::Null(_) => Ok(()),
             TsPayload::Raw(ref x) => track!(x.write_to(writer)),
         }

--- a/src/ts/section.rs
+++ b/src/ts/section.rs
@@ -1,0 +1,20 @@
+use crate::ts::payload::Bytes;
+use crate::Result;
+use byteorder::WriteBytesExt;
+use std::io::Write;
+
+/// Payload for Section Stream packets.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Section {
+    pub pointer_field: u8,
+    pub data: Bytes,
+}
+
+impl Section {
+    pub(super) fn write_to<W: Write>(&self, mut writer: W) -> Result<()> {
+        track_io!(writer.write_u8(self.pointer_field))?;
+        track!(self.data.write_to(writer))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Thanks for all your review of my pull requests!

I need a way to write [SCTE-35](https://wagtail-prod-storage.s3.amazonaws.com/documents/SCTE_35_2022b.pdf) splice data into a TS stream. At this time, reading is not necessary.

SCTE-35 splice_info_section is a short format section stream that normally only spans a single TS packet, but could span multiple packets. The first packet needs the PUSI set and inserts a pointer_field byte. Subsequent packets do not set PUSI and do not have the pointer_field.

`TsPayload::Raw` will work for subsequent packets, but right now, there is not an appropriate `TsPayload` to use for the first payload. It really is a PSI table, but I have a pile of bytes that I don't want to have to parse into a `PsiTable`. Even then, there isn't a `TsPayload` to write a generic `Psi`.

Here is my proposal, but I don't know if it is the right thing to do. It is kind of a very low-level interface for generic section streams. I welcome your feedback.

Again, this is just writing. Reading would take a pretty large change to the reader as it assumes all elementary streams in the PMT are PES and doesn't handle section streams. Maybe we can think about that for another day.