### PR TITLE
Fix PES header reading/writing for specific stream_ids

### DIFF
--- a/src/es/stream_id.rs
+++ b/src/es/stream_id.rs
@@ -4,6 +4,18 @@ use crate::{ErrorKind, Result};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct StreamId(u8);
 impl StreamId {
+    /// `program_stream_map`
+    pub const PROGRAM_STREAM_MAP: u8 = 0xBC;
+
+    /// `private_stream_1`
+    pub const PRIVATE_STREAM_1: u8 = 0xBD;
+
+    /// `padding_stream`
+    pub const PADDING_STREAM: u8 = 0xBE;
+
+    /// `private_stream_2`
+    pub const PRIVATE_STREAM_2: u8 = 0xBF;
+
     /// Minimum value of the identifiers for audio streams.
     pub const AUDIO_MIN: u8 = 0xC0;
 
@@ -15,6 +27,54 @@ impl StreamId {
 
     /// Maximum value of the identifiers for video streams.
     pub const VIDEO_MAX: u8 = 0xEF;
+
+    /// `ECM_stream`
+    pub const ECM_STREAM: u8 = 0xF0;
+
+    /// `EMM_stream`
+    pub const EMM_STREAM: u8 = 0xF1;
+
+    /// Rec. ITU-T H.222.0 | ISO/IEC 13818-1 Annex B or ISO/IEC 13818-6_DSMCC_stream
+    pub const DSM_CC: u8 = 0xF2;
+
+    /// ISO/IEC_13522_stream
+    pub const ISO_13522_STREAM: u8 = 0xF3;
+
+    /// Rec. ITU-T H.222.1 type A
+    pub const H222_1_TYPE_A: u8 = 0xF4;
+
+    /// Rec. ITU-T H.222.1 type B
+    pub const H222_1_TYPE_B: u8 = 0xF5;
+
+    /// Rec. ITU-T H.222.1 type C
+    pub const H222_1_TYPE_C: u8 = 0xF6;
+
+    /// Rec. ITU-T H.222.1 type D
+    pub const H222_1_TYPE_D: u8 = 0xF7;
+
+    /// Rec. ITU-T H.222.1 type E
+    pub const H222_1_TYPE_E: u8 = 0xF8;
+
+    /// `ancillary_stream`
+    pub const ANCILLARY_STREAM: u8 = 0xF9;
+
+    /// ISO/IEC 14496-1_SL-packetized_stream
+    pub const SL_PACKETIZED_STREAM: u8 = 0xFA;
+
+    /// ISO/IEC 14496-1_FlexMux_stream
+    pub const FLEX_MUX_STREAM: u8 = 0xFB;
+
+    /// metadata stream
+    pub const METADATA_STREAM: u8 = 0xFC;
+
+    /// `extended_stream_id`
+    pub const EXTENDED_STREAM_ID: u8 = 0xFD;
+
+    /// reserved data stream
+    pub const RESERVED_DATA_STREAM: u8 = 0xFE;
+
+    /// `program_stream_directory`
+    pub const PROGRAM_STREAM_DIRECTORY: u8 = 0xFF;
 
     /// Makes a new `StreamId` instance.
     pub fn new(id: u8) -> Self {

--- a/src/pes/packet.rs
+++ b/src/pes/packet.rs
@@ -56,6 +56,28 @@ impl PesHeader {
         let stream_id = StreamId::new(track_io!(reader.read_u8())?);
         let packet_len = track_io!(reader.read_u16::<BigEndian>())?;
 
+        if stream_id.as_u8() == StreamId::PROGRAM_STREAM_MAP
+            || stream_id.as_u8() == StreamId::PADDING_STREAM
+            || stream_id.as_u8() == StreamId::PRIVATE_STREAM_2
+            || stream_id.as_u8() == StreamId::ECM_STREAM
+            || stream_id.as_u8() == StreamId::EMM_STREAM
+            || stream_id.as_u8() == StreamId::PROGRAM_STREAM_DIRECTORY
+            || stream_id.as_u8() == StreamId::DSM_CC
+            || stream_id.as_u8() == StreamId::H222_1_TYPE_E
+        {
+            let header = PesHeader {
+                stream_id,
+                priority: false,
+                data_alignment_indicator: false,
+                copyright: false,
+                original_or_copy: false,
+                pts: None,
+                dts: None,
+                escr: None,
+            };
+            return Ok((header, packet_len));
+        }
+
         let b = track_io!(reader.read_u8())?;
         track_assert_eq!(
             b & 0b1100_0000,
@@ -126,6 +148,18 @@ impl PesHeader {
         track_io!(writer.write_uint::<BigEndian>(PACKET_START_CODE_PREFIX, 3))?;
         track_io!(writer.write_u8(self.stream_id.as_u8()))?;
         track_io!(writer.write_u16::<BigEndian>(pes_header_len))?;
+
+        if self.stream_id.as_u8() == StreamId::PROGRAM_STREAM_MAP
+            || self.stream_id.as_u8() == StreamId::PADDING_STREAM
+            || self.stream_id.as_u8() == StreamId::PRIVATE_STREAM_2
+            || self.stream_id.as_u8() == StreamId::ECM_STREAM
+            || self.stream_id.as_u8() == StreamId::EMM_STREAM
+            || self.stream_id.as_u8() == StreamId::PROGRAM_STREAM_DIRECTORY
+            || self.stream_id.as_u8() == StreamId::DSM_CC
+            || self.stream_id.as_u8() == StreamId::H222_1_TYPE_E
+        {
+            return Ok(());
+        }
 
         let n = 0b1000_0000
             | ((self.priority as u8) << 3)


### PR DESCRIPTION
According to  ITU-T H.222.0 `Table 2-21 - PES Packet`, for certain stream_ids, only the first 3 fields of the PES header are used. This PR corrects that and adds additional defines from `Table 2-22 – Stream_id assignments`