### PR TITLE
Fix PES reassembly failure by explicitly distinguishing PES start and continuation TS packets

### DIFF
--- a/src/pes/reader.rs
+++ b/src/pes/reader.rs
@@ -51,7 +51,11 @@ impl<R: ReadTsPacket> PesPacketReader<R> {
         }
     }
 
-    fn handle_pes_payload(&mut self, pid: Pid, pes: Pes) -> Result<Option<PesPacket<Vec<u8>>>> {
+    fn handle_pes_start_payload(
+        &mut self,
+        pid: Pid,
+        pes: Pes,
+    ) -> Result<Option<PesPacket<Vec<u8>>>> {
         let data_len = if pes.pes_packet_len == 0 {
             None
         } else {
@@ -87,7 +91,11 @@ impl<R: ReadTsPacket> PesPacketReader<R> {
         }
     }
 
-    fn handle_raw_payload(&mut self, pid: Pid, data: &Bytes) -> Result<Option<PesPacket<Vec<u8>>>> {
+    fn handle_pes_continuation_payload(
+        &mut self,
+        pid: Pid,
+        data: &Bytes,
+    ) -> Result<Option<PesPacket<Vec<u8>>>> {
         let mut partial = self
             .pes_packets
             .remove(&pid)
@@ -119,8 +127,12 @@ impl<R: ReadTsPacket> ReadPesPacket for PesPacketReader<R> {
         while let Some(ts_packet) = self.ts_packet_reader.read_ts_packet()? {
             let pid = ts_packet.header.pid;
             let result = match ts_packet.payload {
-                Some(TsPayload::Pes(payload)) => self.handle_pes_payload(pid, payload)?,
-                Some(TsPayload::Raw(payload)) => self.handle_raw_payload(pid, &payload)?,
+                Some(TsPayload::PesStart(payload)) => {
+                    self.handle_pes_start_payload(pid, payload)?
+                }
+                Some(TsPayload::PesContinuation(payload)) => {
+                    self.handle_pes_continuation_payload(pid, &payload)?
+                }
                 _ => None,
             };
             if result.is_some() {

--- a/src/ts/packet.rs
+++ b/src/ts/packet.rs
@@ -154,7 +154,8 @@ impl TsHeader {
 pub enum TsPayload {
     Pat(Pat),
     Pmt(Pmt),
-    Pes(Pes),
+    PesStart(Pes),
+    PesContinuation(Bytes),
     Section(Section),
     Null(Null),
     Raw(Bytes),
@@ -164,7 +165,8 @@ impl TsPayload {
         match *self {
             TsPayload::Pat(ref x) => x.write_to(writer),
             TsPayload::Pmt(ref x) => x.write_to(writer),
-            TsPayload::Pes(ref x) => x.write_to(writer),
+            TsPayload::PesStart(ref x) => x.write_to(writer),
+            TsPayload::PesContinuation(ref x) => x.write_to(writer),
             TsPayload::Section(ref x) => x.write_to(writer),
             TsPayload::Null(_) => Ok(()),
             TsPayload::Raw(ref x) => x.write_to(writer),

--- a/src/ts/packet.rs
+++ b/src/ts/packet.rs
@@ -57,7 +57,10 @@ impl TsPacket {
         };
         let payload_unit_start_indicator = !matches!(
             self.payload,
-            Some(TsPayload::Raw(_)) | Some(TsPayload::Null(_)) | None
+            Some(TsPayload::PesContinuation(_))
+                | Some(TsPayload::Raw(_))
+                | Some(TsPayload::Null(_))
+                | None
         );
         self.header.write_to(
             &mut writer,

--- a/src/ts/reader.rs
+++ b/src/ts/reader.rs
@@ -88,10 +88,10 @@ impl<R: Read> ReadTsPacket for TsPacketReader<R> {
                         PidKind::Pes => {
                             if payload_unit_start_indicator {
                                 let pes = Pes::read_from(&mut reader)?;
-                                TsPayload::Pes(pes)
+                                TsPayload::PesStart(pes)
                             } else {
                                 let bytes = Bytes::read_from(&mut reader)?;
-                                TsPayload::Raw(bytes)
+                                TsPayload::PesContinuation(bytes)
                             }
                         }
                     }


### PR DESCRIPTION
## Reproduction
The issue can be reproduced with the following commands:
```bash
ffmpeg -f lavfi -i color=c=green:s=1920x1080:r=25:d=5 \
  -c:v libx264 -pix_fmt yuv420p \
  -f mpegts \
  -metadata service_provider='{"version":"123"}' \
  green.ts
```
```bash
cargo run --example parse -- --output_type pes-packet < green.ts
```

## Problem description
When using an MPEG-TS file that includes metadata as described above, the existing TS/PES demuxing logic fails to parse the stream and terminates with the following error:
```
Error: InvalidInput: PES packet not found for PID (at mpeg2ts/src/pes/reader.rs:94)
```

## Root cause
Previously, TS packets carrying PES continuation data were represented as generic Raw payloads.
As a result:
- The PES reader attempted to treat all raw payloads as PES continuation.
- Valid TS packets were mistakenly routed into PES reassembly
- When such packets arrived without a preceding PES start, the demuxer failed with error.